### PR TITLE
Re-did seeding (To fix prototype journey)

### DIFF
--- a/api/data/seeds/make-company.ts
+++ b/api/data/seeds/make-company.ts
@@ -1,5 +1,5 @@
 import { prisma, NodeType,
-  QuestionNode, LeafNode, Questionnaire } from '../../src/generated/prisma-client/index';
+  QuestionNode, LeafNode, Questionnaire, Maybe, ID_Input } from '../../src/generated/prisma-client/index';
 import { leafNodes, sliderType, standardRootChildren,
   getStandardEdgeData, standardSubChildren } from './seedDataStructure';
 import { Customer } from '../../src/generated/resolver-types';
@@ -204,6 +204,529 @@ export const connectQuestionsToQuestionnaire = async (questionnaireId: string,
   });
 };
 
+const standardOptions = [{ value: 'Facilities' }, { value: 'Website/Mobile app' }, { value: 'Product/Services' }, { value: 'Customer support' }];
+const facilityOptions = [{ value: 'Cleanliness' }, { value: 'Atmosphere' }, { value: 'Location' }, { value: 'Other' }];
+const websiteOptions = [{ value: 'Design' }, { value: 'Functionality' }, { value: 'Informative' }, { value: 'Other' }];
+const customerSupportOptions = [{ value: 'Friendliness' }, { value: 'Competence' }, { value: 'Speed' }, { value: 'Other' }];
+const productServicesOptions = [{ value: 'Quality' }, { value: 'Price' }, { value: 'Friendliness' }, { value: 'Other' }];
+
+export const getCorrectLeaf = (leafs: LeafNode[], titleSubset: string) => {
+  const correctLeaf = leafs.find((leaf) => leaf.title.includes(titleSubset));
+  return correctLeaf?.id;
+};
+
+export const createNodesAndEdges = async (
+  questionnaireId: string,
+  customerName: string,
+  leafs: LeafNode[],
+) => {
+
+  // Root question (How do you feel about?)
+  const rootQuestion = await prisma.createQuestionNode({
+    title: `How do you feel about ${customerName}?`,
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    questionType: sliderType,
+    isRoot: true,
+  });
+
+  // Positive Sub child 1 (What did you like?)
+  const rootToWhatDidYou = await prisma.createQuestionNode({
+    title: 'What did you like?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Follow us on Instagram and stay'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...standardOptions,
+      ],
+    },
+  });
+
+  // Positive Sub sub child 1 (Facilities)
+  const whatDidYouToFacilities = await prisma.createQuestionNode({
+    title: 'What exactly did you like about the facilities?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Come and join us on 1st April for our great event'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...facilityOptions,
+      ],
+    },
+  });
+
+  // Positive Sub sub child 2 (Website)
+  const whatDidYouToWebsite = await prisma.createQuestionNode({
+    title: 'What exactly did you like about the website?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Follow us on Instagram and stay'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...websiteOptions,
+      ],
+    },
+  });
+
+  // Positive Sub sub child 3 (Product/Services)
+  const whatDidYouToProduct = await prisma.createQuestionNode({
+    title: 'What exactly did you like about the product / services?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'We think you might like this as'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...productServicesOptions,
+      ],
+    },
+  });
+
+  // Positive Sub sub child 4 (Customer Support)
+  const whatDidYouToCustomerSupport = await prisma.createQuestionNode({
+    title: 'What exactly did you like about the customer support?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'your email below to receive our newsletter'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...customerSupportOptions,
+      ],
+    },
+  });
+
+  // Neutral Sub child 2
+  const rootToWhatWouldYouLikeToTalkAbout = await prisma.createQuestionNode({
+    title: 'What would you like to talk about?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Leave your email below to receive our'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...standardOptions,
+      ],
+    },
+  });
+
+
+  // Neutral Sub sub child 1 (Facilities)
+  const whatWouldYouLikeToTalkAboutToFacilities = await prisma.createQuestionNode({
+    title: 'Please specify.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...facilityOptions,
+      ],
+    },
+  });
+
+  // Neutral Sub sub child 2 (Website)
+  const whatWouldYouLikeToTalkAboutToWebsite = await prisma.createQuestionNode({
+    title: 'Please specify.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...websiteOptions,
+      ],
+    },
+  });
+
+   // Neutral Sub sub child 3 (Product/Services)
+   const whatWouldYouLikeToTalkAboutToProduct = await prisma.createQuestionNode({
+    title: 'Please specify.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...productServicesOptions,
+      ],
+    },
+  });
+
+  // Neutral Sub sub child 4 (Customer Support)
+  const whatWouldYouLikeToTalkAboutToCustomerSupport = await prisma.createQuestionNode({
+    title: 'Please specify.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...customerSupportOptions,
+      ],
+    },
+  });
+
+  // Negative Sub child 3
+  const rootToWeAreSorryToHearThat = await prisma.createQuestionNode({
+    title: 'We are sorry to hear that! Where can we improve?',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...standardOptions,
+      ],
+    },
+  });
+
+  // Negative Sub sub child 1 (Facilities)
+  const weAreSorryToHearThatToFacilities = await prisma.createQuestionNode({
+    title: 'Please elaborate.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Our team is on it'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...facilityOptions,
+      ],
+    },
+  });
+
+  // Negative Sub sub child 2 (Website)
+  const weAreSorryToHearThatToWebsite = await prisma.createQuestionNode({
+    title: 'Please elaborate.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Please click on the Whatsapp link below so our service'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...websiteOptions,
+      ],
+    },
+  });
+
+  // Negative Sub sub child 3 (Product/Services)
+  const weAreSorryToHearThatToProduct = await prisma.createQuestionNode({
+    title: 'Please elaborate.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Click below for your refund'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...productServicesOptions,
+      ],
+    },
+  });
+
+  // Negative Sub sub child 4 (Customer Support)
+  const weAreSorryToHearThatToCustomerSupport = await prisma.createQuestionNode({
+    title: 'Please elaborate.',
+    questionnaire: {
+      connect: {
+        id: questionnaireId,
+      },
+    },
+    overrideLeaf: {
+      connect: {
+        id: getCorrectLeaf(leafs, 'Our customer experience supervisor is'),
+      },
+    },
+    questionType: 'MULTI_CHOICE',
+    options: {
+      create: [
+        ...customerSupportOptions,
+      ],
+    },
+  });
+
+  // ################################### EDGES ################################
+  const edgeData = [
+    // POSITIVE EDGES
+    {
+      parent: rootQuestion,
+      conditions: {
+        conditionType: 'valueBoundary',
+        matchValue: null,
+        renderMin: 70,
+        renderMax: 100,
+      },
+      child: rootToWhatDidYou,
+    },
+
+    {
+      parent: rootToWhatDidYou,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Facilities',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatDidYouToFacilities,
+    },
+
+    {
+      parent: rootToWhatDidYou,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Website/Mobile app',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatDidYouToWebsite,
+    },
+
+    {
+      parent: rootToWhatDidYou,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Product/Services',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatDidYouToProduct,
+    },
+
+    {
+      parent: rootToWhatDidYou,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Customer Support',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatDidYouToProduct,
+    },
+
+
+    // NEUTRAL EDGES
+    {
+      parent: rootQuestion,
+      conditions: {
+        conditionType: 'valueBoundary',
+        matchValue: null,
+        renderMin: 50,
+        renderMax: 70,
+      },
+      child: rootToWhatWouldYouLikeToTalkAbout,
+    },
+
+    {
+      parent: rootToWhatWouldYouLikeToTalkAbout,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Facilities',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatDidYouToFacilities,
+    },
+
+    {
+      parent: rootToWhatWouldYouLikeToTalkAbout,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Website/Mobile app',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatWouldYouLikeToTalkAboutToWebsite,
+    },
+
+    {
+      parent: rootToWhatWouldYouLikeToTalkAbout,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Product/Services',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatWouldYouLikeToTalkAboutToProduct,
+    },
+
+    {
+      parent: rootToWhatWouldYouLikeToTalkAbout,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Customer Support',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: whatWouldYouLikeToTalkAboutToCustomerSupport,
+    },
+
+    // NEGATIVE EDGES
+    {
+      parent: rootQuestion,
+      conditions: {
+        conditionType: 'valueBoundary',
+        matchValue: null,
+        renderMin: 0,
+        renderMax: 50,
+      },
+      child: rootToWeAreSorryToHearThat,
+    },
+
+    {
+      parent: rootToWeAreSorryToHearThat,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Facilities',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: weAreSorryToHearThatToFacilities,
+    },
+
+    {
+      parent: rootToWeAreSorryToHearThat,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Website/Mobile app',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: weAreSorryToHearThatToWebsite,
+    },
+
+    {
+      parent: rootToWeAreSorryToHearThat,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Product/Services',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: weAreSorryToHearThatToProduct,
+    },
+
+    {
+      parent: rootToWeAreSorryToHearThat,
+      conditions: {
+        conditionType: 'match',
+        matchValue: 'Customer Support',
+        renderMin: null,
+        renderMax: null,
+      },
+      child: weAreSorryToHearThatToCustomerSupport,
+    },
+
+  ];
+  // Root to 'What did you like'
+  const edges = await Promise.all(edgeData.map(async (edge) => {
+    const edgeEntry = await prisma.createEdge({
+      parentNode: {
+        connect: {
+          id: edge.parent.id,
+        },
+      },
+      conditions: {
+        create: [edge.conditions],
+      },
+      childNode: {
+        connect: {
+          id: edge.child.id,
+        },
+      },
+    });
+
+    await prisma.updateQuestionNode({
+      where: {
+        id: edge.parent.id,
+      },
+      data: {
+        edgeChildren: {
+          connect: [{ id: edgeEntry.id }],
+        },
+      },
+    });
+  }));
+};
+
 export const seedQuestions = async (questionnaireId: string) => {
   const rootQuestions = await createQuestionsForQuestionnaire(questionnaireId);
   const mainQuestion = await getRootQuestionOfQuestionnaire(questionnaireId);
@@ -362,18 +885,14 @@ export const seedQuestionnare = async (
     title: questionnaireTitle,
     description: questionnaireDescription,
     questions: {
-      create: [{
-        title: `How do you feel about ${customerName}?`,
-        questionType: sliderType,
-        isRoot: true,
-      },
-      ],
+      create: [],
     },
   });
 
-  await seedQuestions(questionnaire.id);
+  await createNodesAndEdges(questionnaire.id, customerName, leafs);
+  // await seedQuestions(questionnaire.id);
 
-  await seedEdges(customerName, questionnaire.id, leafs);
+  // await seedEdges(customerName, questionnaire.id, leafs);
 
   return questionnaire;
 };
@@ -407,6 +926,28 @@ const seedQuestionnareOfCustomer = async (customer: Customer): Promise<Questionn
   await seedEdges(customer.name, questionnaire.id, leafs);
 
   return questionnaire;
+};
+
+export const seedFreshCompany = async (customer: Customer) => {
+  const leafs = await createTemplateLeafNodes(leafNodes);
+
+  const questionnaire = await prisma.createQuestionnaire({
+    customer: {
+      connect: {
+        id: customer.id,
+      },
+    },
+    leafs: {
+      connect: leafs.map((leaf) => ({ id: leaf.id })),
+    },
+    title: 'Default questionnaire',
+    description: 'Default questions',
+    questions: {
+      create: [],
+    },
+  });
+
+  await createNodesAndEdges(questionnaire.id, customer.name, leafs);
 };
 
 const seedCompany = async (customer: Customer) => {

--- a/api/data/seeds/make-f45.ts
+++ b/api/data/seeds/make-f45.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../src/generated/prisma-client/index';
 
-import seedCompany from './make-company';
+import seedCompany, { seedFreshCompany } from './make-company';
 
 const CUSTOMER = 'F45 Training';
 
@@ -20,7 +20,7 @@ const makef45 = async () => {
     },
   });
 
-  await seedCompany(customer);
+  await seedFreshCompany(customer);
 };
 
 export default makef45;

--- a/api/data/seeds/make-mediamarkt.ts
+++ b/api/data/seeds/make-mediamarkt.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../src/generated/prisma-client/index';
 
-import seedCompany from './make-company';
+import seedCompany, { seedFreshCompany } from './make-company';
 
 const CUSTOMER = 'Mediamarkt';
 
@@ -19,7 +19,7 @@ const makeMediamarkt = async () => {
     },
   });
 
-  await seedCompany(customer);
+  await seedFreshCompany(customer);
 };
 
 export default makeMediamarkt;

--- a/api/data/seeds/make-starbucks.ts
+++ b/api/data/seeds/make-starbucks.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../src/generated/prisma-client/index';
 
-import seedCompany from './make-company';
+import seedCompany, { seedFreshCompany } from './make-company';
 
 const CUSTOMER = 'Starbucks';
 
@@ -19,7 +19,7 @@ const makeStarbucks = async () => {
     },
   });
 
-  await seedCompany(customer);
+  await seedFreshCompany(customer);
 };
 
 export default makeStarbucks;

--- a/api/src/resolvers.ts
+++ b/api/src/resolvers.ts
@@ -4,7 +4,7 @@ import { QueryResolvers, MutationResolvers } from './generated/resolver-types';
 import cleanInt from './utils/cleanInt';
 import _ from 'lodash';
 import { prisma, ID_Input, Questionnaire } from './generated/prisma-client/index';
-import seedCompany, { seedQuestionnare } from '../data/seeds/make-company';
+import seedCompany, { seedQuestionnare, seedFreshCompany } from '../data/seeds/make-company';
 
 const deleteFullCustomerNode = async (parent: any, args:any) => {
   const { id } : { id: ID_Input} = args;
@@ -36,7 +36,7 @@ const createNewCustomerMutation = async (parent : any, args: any) => {
   });
 
   if (isSeed) {
-    await seedCompany(customer);
+    await seedFreshCompany(customer);
   }
 
   return customer;


### PR DESCRIPTION
Redid seeding to match the prototype journey by hardcoding all questions and then connect them to edges by their IDs instead of question titles. Might not be the most elegant solution but it does the trick rather well :) 