### PR TITLE
Disconnect prisma on SIGTERM

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,8 +2,20 @@ import prisma from './config/prisma';
 import config from './config/config';
 import { makeServer } from './config/server';
 
+/**
+ * Terminates the server and other processes (such as Prisma) when the process is killed.
+ * - SIGTERM is triggered by AWS Fargate. Prisma only watches for SIGINT.
+ */
+process.on('SIGTERM', async () => {
+  console.log('App Lifecycle: Disconnecting from prisma');
+  await prisma.$disconnect()
+
+  console.log('App Lifecycle: Disconnecting child');
+  process.exit(0);
+});
+
 try {
-  console.log('Starting app');
+  console.log('App Lifecycle: Starting app');
   makeServer(config.port, prisma);
 } catch (e) {
   console.log(e);

--- a/api/src/config/prisma.ts
+++ b/api/src/config/prisma.ts
@@ -17,6 +17,10 @@ const prisma = new PrismaClient({
   ]
 });
 
+prisma.$on('beforeExit', () => {
+  console.log('Prisma: BeforeExit is being run (it is disconnecting)');
+})
+
 if (process.env.ENVIRONMENT === 'debug') {
   prisma.$on('query', (event) => {
     console.log(event.query);


### PR DESCRIPTION
# Problem
Prisma listens for SIGINT according to this [this issue](https://github.com/prisma/prisma/issues/2917). Meanwhile when, we autoscale our fargate containers, when we remove a container, the node-process likely receives a SIGTERM signal, according to the [AWS docs](https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/). This implies that whenever a container is shut-down with the SIGINT signal, the prisma child-processes might still be running in some way.

# Solution
As such, the solution is to do an explicit disconnect on SIGTERM (with some logging). Furthermore, I added some logging, including one on prisma's `beforeExit` event, so that we can figure out if the instance is being disconnected.