### PR TITLE
Dashboard Test Tool: Wait for Request

### DIFF
--- a/frontend/dashboard/src/test/index.tsx
+++ b/frontend/dashboard/src/test/index.tsx
@@ -2,5 +2,6 @@ export * from '@testing-library/react';
 export { default as userEvent } from '@testing-library/user-event';
 
 export * from './expects/expectCustomerLoaded';
+export * from './utils/waitForRequest';
 export { render } from './render';
 export { server } from './server';

--- a/frontend/dashboard/src/test/utils/waitForRequest.tsx
+++ b/frontend/dashboard/src/test/utils/waitForRequest.tsx
@@ -1,0 +1,44 @@
+import { GraphQLJsonRequestBody, MockedRequest } from 'msw';
+import { SetupServerApi } from 'msw/node';
+
+/**
+ * Defines a listener for a request. The listener will wait for a specific mutation to fire, which can be awaited when
+ * the mutation is to have fired.
+ *
+ * How to use it:
+ * 1. Call `waitForRequest` with the request you want to wait for before the mutation is fired.
+      *  This will return a `Promise` that resolves later when the mutation is fired.
+ * 2. Simulate the action that is supposed to fire (such as a click).
+ * 3. Await the `Promise` returned by `waitForRequest`.
+ *
+ * Example:
+ * ```
+ * const waitForRequest = waitForRequest(server, 'createUser');
+ * createUserButton.click();
+ * await waitForRequest;
+ * ```
+ *
+ * Note: This function tests the implementation, and is not necessarily a best practice. But currently, this
+ * is the only way to test form submits.
+ */
+export const waitForRequest = <QueryVariables, >(server: SetupServerApi, resolver: string): Promise<MockedRequest<GraphQLJsonRequestBody<QueryVariables>>> => {
+  let requestId = ''
+  return new Promise((resolve, reject) => {
+      server.events.on('request:start', (req: any) => {
+          const matchesMethod = req.body.operationName.toLowerCase() === resolver.toLowerCase()
+          if (matchesMethod) { requestId = req.id }
+      })
+      server.events.on('request:match', (req) => {
+          if (req.id === requestId) {
+              resolve(req as MockedRequest<GraphQLJsonRequestBody<QueryVariables>>)
+          }
+      })
+      server.events.on('request:unhandled', (req) => {
+          if (req.id === requestId) {
+              reject(
+                  new Error(`The ${req.method} ${req.url.href} request was unhandled.`),
+              )
+          }
+      })
+  })
+}


### PR DESCRIPTION
# Description
In order for us to test form-submits and API calls, it is unfortunately necessary to have a listener that listens for form-submits. This is unfortunately not best practice, but I can't see another way for us to test that when a form is submitted, the right data gets sent to the backend (since backend tests and frontend tests are currently a bit split).

That's why I added a `waitForRequest` handler, which hooks into the mockServiceWorker's event lifecycle, based on https://mswjs.io/docs/extensions/life-cycle-events#tracking-a-request. The JSDocs of the method should be clear enough, but the goal is to examine the response of the request in our test and validate that the right props are sent to the backend.

Note: if we can find a better way of testing the form submissions that somehow conform to testing the implementation (e.g. either an alternative to testing them, or a visual representation indicator that they worked), we should replace this technique.
