### PR TITLE
Dialogue builder improvement: Logical order questions

### DIFF
--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -60,6 +60,7 @@
     "react-simplemde-editor": "^4.1.3",
     "styled-components": "^5.2.1",
     "styled-system": "^5.1.4",
+    "ts-is-present": "^1.2.2",
     "typescript": "^4.1.3",
     "use-query-params": "^1.2.3",
     "vite": "^2.4.2",

--- a/frontend/dashboard/src/pages/dashboard/builder/index.tsx
+++ b/frontend/dashboard/src/pages/dashboard/builder/index.tsx
@@ -108,6 +108,7 @@ const mapQuestionsInputData = (nodes: QuestionEntryProps[]) => {
           },
         options: options?.map((option) => ({
           id: option.id,
+          position: option.position,
           value: option.value,
           publicValue: option.publicValue,
           overrideLeaf: option.overrideLeaf,

--- a/frontend/dashboard/src/views/DialogueBuilderView/components/QuestionSection.tsx
+++ b/frontend/dashboard/src/views/DialogueBuilderView/components/QuestionSection.tsx
@@ -1,5 +1,7 @@
 import { Div, Flex, H4 } from '@haas/ui';
 import { Plus } from 'react-feather';
+import { isPresent } from 'ts-is-present';
+import { orderBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import React, { useState } from 'react';
 
@@ -35,6 +37,17 @@ interface QuestionSectionProps {
   problems?: (QuestionNodeProblem | undefined)[];
 }
 
+const orderByOptions = (question: QuestionEntryProps) => {
+  const { options } = question;
+  const { children } = question;
+  const orderedOptions = orderBy(options, (option) => option.position, 'asc');
+  const mappedOptionChildren = orderedOptions.map((option) => {
+    const optionChild = children?.find((child) => child.conditions[0].matchValue === option.value);
+    return optionChild;
+  }).filter(isPresent);
+  return mappedOptionChildren;
+};
+
 const QuestionSection = ({
   index,
   activeQuestion,
@@ -60,22 +73,15 @@ const QuestionSection = ({
     setQuestionExpanded((prevExpanded) => !prevExpanded);
   };
 
-  const activeChildrenIds = question.children?.map((child) => child.childNode.id);
-  const children: QuestionEntryProps[] = questionsQ.filter((childQuestion) => (
-    activeChildrenIds?.includes(childQuestion.id)
-  ));
+  const orderedChildren = question.type === 'Slider'
+    ? orderBy(question.children, (child) => child.conditions[0].renderMin, 'asc')
+    : orderByOptions(question);
 
-  // const mappedOptions = options?.map((option) => ({
-  //   id: option.id,
-  //   position: option.position,
-  //   value: option.value,
-  //   publicValue: option.publicValue,
-  //   overrideLeaf: {
-  //     label: option.overrideLeaf?.title,
-  //     value: option.overrideLeaf?.id,
-  //     type: option.overrideLeaf?.type,
-  //   },
-  // })) || [];
+  const activeChildrenIds = orderedChildren?.map((child) => child.childNode.id);
+
+  const children = activeChildrenIds?.map(
+    (childId) => questionsQ.find((childQuestion) => childQuestion.id === childId) as QuestionEntryProps,
+  ) as QuestionEntryProps[];
 
   const parentOptions = question?.options?.map((option) => ({
     id: option.id,
@@ -133,7 +139,7 @@ const QuestionSection = ({
         onActiveQuestionChange={onActiveQuestionChange}
         onAddQuestion={onAddQuestion}
         onDeleteQuestion={onDeleteQuestion}
-        key={`entry-${question.id}-${question.updatedAt}`}
+        key={`entry-${question.id}`}
         index={0}
         questionsQ={questionsQ}
         question={question}
@@ -158,7 +164,7 @@ const QuestionSection = ({
           onActiveQuestionChange={onActiveQuestionChange}
           question={child}
           questionsQ={questionsQ}
-          key={`section-${child.id}-${child.updatedAt}`}
+          key={`section-${child.id}`}
           problems={childConditionsProblems[childIndex]}
           onAddQuestion={onAddQuestion}
           onDeleteQuestion={onDeleteQuestion}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22473,6 +22473,11 @@ ts-is-present@^1.1.3:
   resolved "https://registry.yarnpkg.com/ts-is-present/-/ts-is-present-1.2.1.tgz#38faeef8c59a890c0f876c86a46397fab236e21c"
   integrity sha512-EYHn58qVRd/VHGkHSNGQJAxPXhF9wRiphYXl04VznngqqKjcT2jfHvAMPuzh8sRKdvifXw+dq6/Q3hG+nr3DRA==
 
+ts-is-present@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/ts-is-present/-/ts-is-present-1.2.2.tgz#ba59b4a9d2bc22b99d1ba7f4af3d5eb320408d95"
+  integrity sha512-cA5MPLWGWYXvnlJb4TamUUx858HVHBsxxdy8l7jxODOLDyGYnQOllob2A2jyDghGa5iJHs2gzFNHvwGJ0ZfR8g==
+
 ts-jest@^26.4.4, ts-jest@^26.5.6:
   version "26.5.6"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"


### PR DESCRIPTION
Fixes HAAS-123
This PR fixes an longstanding issue where questions in the dialogue builder are randomly ordered.
Now: 
- Slider question children are ordered from low to high
- Any other option (Video/Choice) are ordered based on the position of the corresponding option