### PR TITLE
Scroll to top

### DIFF
--- a/frontend/dashboard/src/components/Utilities/ScrollToTop.tsx
+++ b/frontend/dashboard/src/components/Utilities/ScrollToTop.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * On each page transition, scroll the app to the top of the screen (to prevent)
+ * users from being suddenly "lost" on the app.
+ */
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/frontend/dashboard/src/config/AppProviders.tsx
+++ b/frontend/dashboard/src/config/AppProviders.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { AppContainer } from 'styles/AppStyles';
 import { DefaultThemeProviders } from 'providers/ThemeProvider';
 import { GlobalErrorFallback } from 'components/Error/GlobalErrorFallback';
+import { ScrollToTop } from 'components/Utilities/ScrollToTop';
 import UserProvider from 'providers/UserProvider';
 
 import GlobalStyle from './global-styles';
@@ -21,6 +22,7 @@ import lang from './i18n-config';
 export const AppProviders = ({ children }: { children: React.ReactNode }) => (
   <I18nextProvider i18n={lang}>
     <Router>
+      <ScrollToTop />
       <ErrorBoundary fallback={GlobalErrorFallback}>
         <ApolloProvider client={client}>
           <DefaultThemeProviders>


### PR DESCRIPTION
Closes HAAS-310

Ensures that app scrolls to the top on each page transition. Sometimes, you might scroll down on one page, and transition to a new being completely at the bottom of that page (and thus missing particular context).