### PR TITLE
Workspace: Visual height bug

### DIFF
--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.styles.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.styles.tsx
@@ -5,7 +5,6 @@ import styled, { css } from 'styled-components';
 export const WorkspaceGridAdapterContainer = styled(UI.Div)`
   ${({ theme }) => css`
     border: 1px solid ${theme.colors.gray[200]};
-    height: 100vh;
   `}
 `;
 

--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.tsx
@@ -277,7 +277,7 @@ export const WorkspaceGrid = ({
         </motion.div>
       )}
 
-      <UI.Div height="calc(100vh - 30px)" borderRadius={20} position="relative">
+      <UI.Div minHeight="calc(100vh - 30px)" borderRadius={20} position="relative">
         <Zoom<SVGElement>
           width={width}
           height={height}
@@ -342,7 +342,7 @@ export const WorkspaceGrid = ({
                   </HexagonGrid>
 
                 </UI.Div>
-                <UI.Div mt={4}>
+                <UI.Div my={4}>
                   <WorkspaceSummaryPane
                     startDate={startDate}
                     endDate={endDate}

--- a/frontend/dashboard/src/views/DashboardView/DashboardView.tsx
+++ b/frontend/dashboard/src/views/DashboardView/DashboardView.tsx
@@ -7,7 +7,7 @@ import theme from 'config/theme';
 
 export const DashboardView = () => (
   <View documentTitle="haas | Overview">
-    <UI.Div height="100vh">
+    <UI.Div>
       <UI.Div>
         <WorkspaceGridAdapter
           backgroundColor={theme.colors.neutral[500]}


### PR DESCRIPTION
No Linear issue linked, but known problem

The height scaling was broken in previous build.
In this build, it is fixed:

## Before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9025544/173255510-48d97e70-4209-4578-a89a-80c2dad46670.png">

## After
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/9025544/173255489-4a185977-498d-463e-908d-350843d3e63b.png">