### PR TITLE
Add all CTAs to DEFAULT workspace template and set up different test cases

### DIFF
--- a/api/src/models/QuestionNode/NodeService.ts
+++ b/api/src/models/QuestionNode/NodeService.ts
@@ -468,10 +468,7 @@ export class NodeService {
     overrideLeafId: string = '',
     isLeaf: boolean = false
   ) => {
-    const qOptions = options.length > 0 ? [
-      ...options,
-    ] : [];
-
+    const qOptions = options.length > 0 ? options : [];
     const params: CreateQuestionInput =
     {
       isRoot,

--- a/api/src/models/QuestionNode/NodeServiceType.ts
+++ b/api/src/models/QuestionNode/NodeServiceType.ts
@@ -15,6 +15,7 @@ export interface QuestionOptionProps {
   id?: number;
   value: string;
   publicValue?: string | null;
+  isTopic?: boolean;
   overrideLeafId?: string;
   position: number | null;
 }

--- a/api/src/models/questionnaire/DialoguePrismaAdapter.ts
+++ b/api/src/models/questionnaire/DialoguePrismaAdapter.ts
@@ -298,6 +298,9 @@ class DialoguePrismaAdapter {
                 videoUrl: question.videoEmbeddedNode.videoUrl,
               },
             } : undefined,
+            share: {
+              create: question.share,
+            },
             links: question.links?.length ? {
               create: question.links,
             } : undefined,

--- a/api/src/models/questionnaire/DialoguePrismaAdapterType.ts
+++ b/api/src/models/questionnaire/DialoguePrismaAdapterType.ts
@@ -68,6 +68,11 @@ export interface CreateQuestionInput {
       position: number;
     }>;
   };
+  share?: {
+    url: string;
+    tooltip: string;
+    title: string;
+  };
   sliderNode?: {
     markers: Array<{
       label: string;

--- a/api/src/models/templates/TemplateService.ts
+++ b/api/src/models/templates/TemplateService.ts
@@ -412,30 +412,28 @@ class TemplateService {
     );
 
     // Positive Sub child 1 (What did you like?)
-    const instagramNodeId = TemplateService.findLeafIdContainingText(leafs, 'Follow us on Instagram and stay');
+    const singleLinkCTAId = TemplateService.findLeafIdContainingText(leafs, 'Single link CTA');
     const rootToWhatDidYou = await this.nodeService.createQuestionNode(
       'What did you like?', dialogueId, NodeType.CHOICE, standardOptions, false,
-      instagramNodeId,
+      singleLinkCTAId,
     );
 
     // Positive Sub sub child 1 (Facilities)
-    const comeAndJoin1stAprilId = TemplateService.findLeafIdContainingText(leafs,
-      'Come and join us on 1st April for our great event');
     const whatDidYouToFacilities = await this.nodeService.createQuestionNode(
       'What exactly did you like about the facilities?', dialogueId,
-      NodeType.CHOICE, facilityOptions, false, comeAndJoin1stAprilId,
+      NodeType.CHOICE, facilityOptions, false, undefined,
     );
 
     // Positive Sub sub child 2 (Website)
     const whatDidYouToWebsite = await this.nodeService.createQuestionNode(
       'What exactly did you like about the website?', dialogueId,
-      NodeType.CHOICE, websiteOptions, false, instagramNodeId,
+      NodeType.CHOICE, websiteOptions, false, undefined,
     );
 
     // Positive Sub sub child 3 (Product/Services)
-    const weThinkYouMightLikeThis = TemplateService.findLeafIdContainingText(
+    const shareCTA = TemplateService.findLeafIdContainingText(
       leafs,
-      'We think you might like this as',
+      'Share CTA',
     );
 
     const whatDidYouToProduct = await this.nodeService.createQuestionNode(
@@ -444,15 +442,21 @@ class TemplateService {
       NodeType.CHOICE,
       productServicesOptions,
       false,
-      weThinkYouMightLikeThis,
+      shareCTA,
     );
 
     // Positive Sub sub child 4 (Customer Support)
-    const yourEmailBelowForNewsletter = TemplateService.findLeafIdContainingText(leafs,
-      'your email below to receive our newsletter');
+    const InstagramMultiLinkCTA = TemplateService.findLeafIdContainingText(leafs,
+      'Instagram');
     const whatDidYouToCustomerSupport = await this.nodeService.createQuestionNode(
       'What exactly did you like about the customer support?', dialogueId,
-      NodeType.CHOICE, customerSupportOptions, false, yourEmailBelowForNewsletter,
+      NodeType.CHOICE,
+      [
+        { value: 'Friendliness', position: 1 },
+        { value: 'Competence', position: 2 },
+        { value: 'Speed', position: 3 },
+        { value: 'Other', position: 4, overrideLeafId: InstagramMultiLinkCTA },
+      ], false, undefined,
     );
 
     // Neutral Sub child 2

--- a/api/src/models/templates/TemplateTypes.ts
+++ b/api/src/models/templates/TemplateTypes.ts
@@ -1,4 +1,4 @@
-import { Prisma, TagEnum } from '@prisma/client';
+import { Link, Prisma, TagEnum } from '@prisma/client';
 import { NexusGenInputs } from '../../generated/nexus';
 
 export interface Tag {
@@ -21,8 +21,8 @@ export interface WorkspaceTemplate {
   tags: Tag[];
   rootSliderOptions: {
     markers: any[];
-    happyText?: string,
-    unhappyText?: string,
+    happyText?: string;
+    unhappyText?: string;
   };
   postLeafText?: {
     header: string;
@@ -58,6 +58,16 @@ export const defaultForm: NexusGenInputs['FormNodeInputType'] = {
     },
   ],
 };
+
+export const singleLink: Partial<Link>[] = [
+  {
+    url: 'https://www.haas.live/',
+    type: 'SINGLE',
+    header: 'Join the stanford summer program',
+    subHeader: 'Get the best out of yourself with our 30-day fit program!',
+    imageUrl: 'https://res.cloudinary.com/haas-storage/image/upload/v1655796025/sellable_items/aa6h8testdtftgy9m3bk.png',
+  },
+]
 
 export const defaultLinks: any[] = [
   { url: 'https://facebook.com', type: 'FACEBOOK', backgroundColor: '#1877f2' },

--- a/api/src/models/templates/defaultWorkspaceTemplate.ts
+++ b/api/src/models/templates/defaultWorkspaceTemplate.ts
@@ -1,5 +1,5 @@
 import { NodeType, Prisma } from '@prisma/client';
-import WorkspaceTemplate, { Tag, defaultAdminRole, defaultBotRole, defaultForm, defaultLinks, defaultManagerRole, defaultUserRole, DemoWorkspaceTemplate } from './TemplateTypes';
+import WorkspaceTemplate, { Tag, defaultAdminRole, defaultBotRole, defaultForm, defaultLinks, defaultManagerRole, defaultUserRole, DemoWorkspaceTemplate, singleLink } from './TemplateTypes';
 
 export type rootTopics = 'Facilities' | 'Website/Mobile app' | 'Product/Services' | 'Customer Support'
 
@@ -15,6 +15,12 @@ export interface MassSeedTemplate extends WorkspaceTemplate {
   rootSliderOptions: any;
 }
 
+/**
+ * Single Link CTA: Positive path => Website => Any option
+ * Share CTA (Also to test overriding CTA as single link CTA is set on layer above): Positive path => Product/Services => Any option
+ * Form CTA: Neutral path => any option => any option
+ * Multi Link CTA: Positive path => Customer support => Other (It is set on question option instead of on question)
+ */
 const defaultWorkspaceTemplate: DemoWorkspaceTemplate = {
   title: 'How do you feel about us?',
   slug: 'default',
@@ -51,7 +57,7 @@ const defaultWorkspaceTemplate: DemoWorkspaceTemplate = {
   ],
   postLeafText: {
     header: 'Thank you for your input!',
-    subHeader: 'Work should be fulfilling'
+    subHeader: 'Work should be fulfilling',
   },
   rootSliderOptions: {
     markers: [
@@ -84,10 +90,18 @@ const defaultWorkspaceTemplate: DemoWorkspaceTemplate = {
   },
   leafNodes: [
     {
-      title:
-        'We are happy about your positive feedback. You matter to us! Leave your contact details below to receive our newsletter.',
-      type: NodeType.TEXTBOX,
-      links: [],
+      title: 'Share CTA',
+      type: NodeType.SHARE,
+      share: {
+        title: 'Get a discount for your friend',
+        url: 'https://www.haas.live/',
+        tooltip: 'Share',
+      },
+    },
+    {
+      title: 'Single link CTA',
+      type: NodeType.LINK,
+      links: singleLink,
     },
     {
       title: 'Thank you for your elaborate feedback. Kindly appreciated!',
@@ -108,7 +122,7 @@ const defaultWorkspaceTemplate: DemoWorkspaceTemplate = {
     },
     {
       title:
-        'Thank you for your positive feedback. Follow us on Instagram and stay updated.',
+        'Thank you for your positive feedback. Follow us on Instagram or other social media and stay updated.',
       type: NodeType.LINK,
       links: defaultLinks,
     },


### PR DESCRIPTION
### In this PR

- Add all current supported CTAs to our default workspace template and connect them to a few questions so they can be automatically tested

Test case: Normal flows
Form CTA: Neutral path => any option => any option
Single Link CTA: Positive path => Website => Any option

Test case: Overriding CTA using CTA set on question one layer below
Share CTA (Also to test overriding CTA as single link CTA is set on layer above): Positive path => Product/Services => Any option

Test case: Override CTA using CTA set on question option
Multi Link CTA: Positive path => Customer support => Other (It is set on question option instead of on question)