### PR TITLE
Hexagons: Fix Zoomlevels and Bring back dragging

### DIFF
--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/HexagonGrid.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/HexagonGrid.tsx
@@ -6,7 +6,7 @@ import { ProvidedZoom } from '@visx/zoom/lib/types';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
 import { localPoint } from '@visx/event';
 import { useTranslation } from 'react-i18next';
-import React, { useState } from 'react';
+import React, { Ref, useState } from 'react';
 import useMeasure from 'react-use-measure';
 
 import * as Tooltip from 'components/Common/Tooltip/Tooltip';
@@ -71,7 +71,7 @@ export const HexagonGrid = ({
   children,
 }: HexagonGridProps) => {
   const { t } = useTranslation();
-  const [ref, bounds] = useMeasure({
+  const [ref] = useMeasure({
     debounce: {
       resize: 2,
       scroll: 1,
@@ -116,7 +116,9 @@ export const HexagonGrid = ({
       <svg
         width={width}
         height={height}
+        ref={zoom.containerRef as Ref<SVGSVGElement>}
         style={{
+          cursor: zoom.isDragging ? 'grabbing' : 'grab',
           touchAction: 'none',
           borderRadius: '10px',
           border: '1px solid #D6DCF2',
@@ -148,14 +150,11 @@ export const HexagonGrid = ({
         )}
         <motion.g
           initial={{ transform: 'matrix(1, 0, 0, 1, 0, 0', opacity: 0 }}
-          style={{ transform: 'matrix(1, 0, 0, 1, 0, 0' }}
           animate={{ transform: zoom.toString(), opacity: 1 }}
         >
-          <Group top={130} left={130}>
+          <Group>
             <motion.g
               ref={ref}
-              x={-10 + (width - bounds.width) / 2}
-              y={(height - bounds.height) / 2}
             >
               <AnimatePresence>
                 <motion.g

--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.helpers.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.helpers.tsx
@@ -287,7 +287,7 @@ export const createGrid = (nrItems: number, windowHeight: number, windowWidth: n
   const ratioWindow = windowWidth / windowHeight;
   const itemsPerRow = Math.ceil(squareRoot * ratioWindow) || 1;
   const itemsPerColumn = Math.ceil(squareRoot) || 1;
-  const dimensions = Math.floor((windowWidth / itemsPerRow) / 2);
+  const dimensions = Math.floor((windowWidth / itemsPerRow) / 3.5);
 
   const hexPrototype = createHexPrototype({
     dimensions,

--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGrid.tsx
@@ -467,6 +467,14 @@ export const WorkspaceGrid = ({
             <Zoom<SVGElement>
               width={width}
               height={height}
+              initialTransformMatrix={{
+                translateX: width / 2.5,
+                translateY: height / 2,
+                scaleX: 1,
+                scaleY: 1,
+                skewX: 0,
+                skewY: 0,
+              }}
               scaleYMax={1.5}
               scaleYMin={0.5}
             >

--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGridAdapter.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/WorkspaceGridAdapter.tsx
@@ -13,8 +13,6 @@ import { Dialogue, HexagonNode, HexagonNodeType, HexagonViewMode } from './Works
 import { groupsFromDialogues, mapNodeTypeToViewType } from './WorkspaceGrid.helpers';
 
 export interface WorkspaceGridAdapterProps {
-  height: number;
-  width: number;
   backgroundColor: string;
 }
 
@@ -24,8 +22,6 @@ export interface WorkspaceGridAdapterProps {
  * @returns
  */
 export const WorkspaceGridAdapter = ({
-  height,
-  width,
   backgroundColor,
 }: WorkspaceGridAdapterProps) => {
   const { getOneWeekAgo, format, getEndOfToday } = useDate();
@@ -41,7 +37,7 @@ export const WorkspaceGridAdapter = ({
 
   const { activeCustomer } = useCustomer();
 
-  const { loading: workspaceLoading } = useGetWorkspaceDialogueStatisticsQuery({
+  useGetWorkspaceDialogueStatisticsQuery({
     variables: {
       startDateTime: format(selectedStartDate, DateFormat.DayFormat),
       endDateTime: format(selectedEndDate, DateFormat.DayFormat),
@@ -101,8 +97,6 @@ export const WorkspaceGridAdapter = ({
 
   // TODO: Add spinner
   if (!dialogues.length) return null;
-
-  const isServerLoading = workspaceLoading;
 
   return (
     <LS.WorkspaceGridAdapterContainer>

--- a/frontend/dashboard/src/components/Analytics/WorkspaceGrid/__tests__/WorkspaceGridAdapter.test.tsx
+++ b/frontend/dashboard/src/components/Analytics/WorkspaceGrid/__tests__/WorkspaceGridAdapter.test.tsx
@@ -5,7 +5,7 @@ import { WorkspaceGridAdapter } from '../WorkspaceGridAdapter';
 import { mockGetWorkspaceDialogueStatistics, mockQueryDialogueConnection } from './helpers';
 
 const renderComponent = () => {
-  render(<WorkspaceGridAdapter backgroundColor="red" height={100} width={100} />);
+  render(<WorkspaceGridAdapter backgroundColor="red" />);
 };
 
 test('render layers', async () => {

--- a/frontend/dashboard/src/views/DashboardView/DashboardView.tsx
+++ b/frontend/dashboard/src/views/DashboardView/DashboardView.tsx
@@ -11,8 +11,6 @@ export const DashboardView = () => (
       <UI.Div>
         <WorkspaceGridAdapter
           backgroundColor={theme.colors.neutral[500]}
-          height={600}
-          width={900}
         />
       </UI.Div>
     </UI.Div>


### PR DESCRIPTION
Fixes HAAS-400

Now that the grid is not intervening any longer with regular scroll flows (since it is on the side), the grid can be scrolled again with mouse. 

Furthermore, the default zoom levels have beenrelaxed a bit, and the initial rendering of the hexagons are "more centered" (not perfect, will perfect it if it starts to bother).

<img width="652" alt="CleanShot 2022-09-25 at 21 38 34@2x" src="https://user-images.githubusercontent.com/9025544/192162057-f1fb2b78-e048-4fae-baaf-09ca68b1aa61.png">

